### PR TITLE
Hotfix breaking change in vrl2csv.

### DIFF
--- a/R/util-vrl2csv.r
+++ b/R/util-vrl2csv.r
@@ -118,7 +118,6 @@ vrl2csv <- function(vrl, outDir=NA, overwrite=TRUE, vueExePath=NA){
   fileCheck <- file.exists(outFName)
   
   cat('\n')
-  print(outFName[fileCheck])
   
   # Warn if any files were not created.
   if(any(!fileCheck)){
@@ -126,4 +125,7 @@ vrl2csv <- function(vrl, outDir=NA, overwrite=TRUE, vueExePath=NA){
       warning(basename(outFName[!fileCheck][i]), " was not created.")
     }
   }
+  
+  return(outFName[fileCheck])
+  
 }

--- a/tests/testthat/test-vrl2csv.r
+++ b/tests/testthat/test-vrl2csv.r
@@ -1,0 +1,86 @@
+context("Check vrl2csv")
+
+
+## Access internal VRL
+myVRL <- system.file("extdata", "VR2W_109924_20110718_1.vrl",
+                     package = "glatos")
+
+## Create temp_dir with spaces in the file path
+temp_dir <- tempdir()
+test_dir <- file.path(temp_dir, 'test dir')
+dir.create(test_dir)
+
+## Copy internal VRL to test_dir
+good_vrl <- file.path(test_dir, basename(myVRL))
+file.copy(myVRL, good_vrl)
+
+## Run vrl2csv
+good_csv <- vrl2csv(good_vrl,
+                    outDir = test_dir,
+                    vueExePath = 'C:/Program Files (x86)/VEMCO/VUE')
+
+## Get first 10 lines
+csv_f10 <- readLines(good_csv, n = 10)
+
+csv_f10_shouldBe <- 
+  c("ï»¿Date and Time (UTC),Receiver,Transmitter,Transmitter Name,Transmitter Serial,Sensor Value,Sensor Unit,Station Name,Latitude,Longitude", 
+    "2011-04-11 20:17:49,VR2W-109924,A69-1303-63366,,,,,,+0,+0", 
+    "2011-05-08 05:38:32,VR2W-109924,A69-9002-4043,,,5,ADC,,+0,+0", 
+    "2011-05-08 05:41:09,VR2W-109924,A69-9002-4043,,,7,ADC,,+0,+0", 
+    "2011-05-08 05:43:14,VR2W-109924,A69-9002-4043,,,4,ADC,,+0,+0", 
+    "2011-05-08 05:44:15,VR2W-109924,A69-9002-4043,,,5,ADC,,+0,+0", 
+    "2011-05-08 05:45:59,VR2W-109924,A69-9002-4043,,,16,ADC,,+0,+0", 
+    "2011-05-08 05:46:36,VR2W-109924,A69-9002-4043,,,5,ADC,,+0,+0", 
+    "2011-05-08 05:48:07,VR2W-109924,A69-9002-4043,,,6,ADC,,+0,+0", 
+    "2011-05-08 05:48:31,VR2W-109924,A69-9002-4043,,,4,ADC,,+0,+0"
+  )
+
+## Delete the CSV that was just made
+file.remove(good_csv)
+
+
+# Check csv from one VRL in dir with space in name
+test_that("one vrl in dir with space in name gives expected result", {
+  # Check if expected and actual results are the same
+  expect_equal(csv_f10, csv_f10_shouldBe)
+})
+
+
+
+## Make an extra VRL to show behavior if one of group of VRLs is not encoded
+corrupt_vrl <- file.path(test_dir, 'corrupt.vrl')
+file.copy(myVRL, corrupt_vrl)
+
+## Corrupt one of the VRLs
+write(c('SOMEgibberish'), corrupt_vrl)
+
+## Try to import
+msg <- tryCatch(vrl2csv(c(corrupt_vrl, good_vrl),
+                       outDir = test_dir,
+                       vueExePath = 'C:/Program Files (x86)/VEMCO/VUE'),
+                warning = function(w) w$message)
+
+## Get first 10 lines
+csv2_f10 <- readLines(good_csv, n = 10)
+
+
+# Delete temp_dir
+unlink(temp_dir, recursive = TRUE)
+
+
+# Check csv from batch with corrupted VRL in dir with space in name
+test_that("one good vrl in dir with corrupt vrl gives expected result", {
+  # Check if expected and actual results are the same
+  expect_equal(csv2_f10, csv_f10_shouldBe)
+})
+
+# Check warning msg when corrupted vrl
+
+msg_shouldBe <- "corrupt.csv was not created."
+
+test_that("warning with corrupt vrl gives expected result", {
+  # Check if expected and actual results are the same
+  expect_equal(msg, msg_shouldBe)
+})
+
+


### PR DESCRIPTION
@chrisholbrook paths are now returned and it should fix the breaking change from #167 . Note that if no files are created, a character vector of length 0 is returned -- I think this is the same behavior as before.

```
## Access internal VLR
myVRL <- system.file("extdata", "VR2W_109924_20110718_1.vrl",
                     package="glatos")

## Create tempdir with spaces in the file path
temp_dir <- tempdir()
test_dir <- file.path(temp_dir, 'test dir')
dir.create(test_dir)

## Copy internal VLR to tempir
file.copy(myVRL, test_dir)

## Check files
list.files(test_dir, full.names = T)

## Run vrl2csv
return_path <- vrl2csv(list.files(test_dir, full.names = T, pattern = '*.vrl'),
                       outDir = test_dir,
                       vueExePath = 'C:/Program Files (x86)/VEMCO/VUE')

## Check that path is returned
return_path

## Check that CSV was created
list.files(test_dir)
readLines(list.files(test_dir, full.names = T, pattern = '*.csv'), 10)




## Delete the CSV that was just made
file.remove(list.files(test_dir, full.names = T, pattern = '*.csv'))

## Make an extra VRL to show behavior if one of group of VRLs is not encoded
file.copy(myVRL, file.path(test_dir, 'copy.vrl'))

## Corrupt one of the VRLs
write(c('SOMEgibberish'), list.files(test_dir, full.names = T, pattern = 'vrl')[1])

## Try to import
return_path <- vrl2csv(list.files(test_dir, full.names = T, pattern = '*.vrl'),
                       outDir = test_dir,
                       vueExePath = 'C:/Program Files (x86)/VEMCO/VUE')

## Check that path is returned
return_path


# Delete tempdir
unlink(temp_dir, recursive = T)
```