### PR TITLE
welcoming sp back on a temporary basis

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,6 +26,7 @@ Imports:
 		readxl,
 		rmarkdown,
 		sf,
+		sp,
 		tibble,
 		tidyr
 Suggests: 


### PR DESCRIPTION
Since `sp` didn't deprecate with the `rgdal` `rgeos` debacle, we can have it around for a while yet. This should be the last little thing that fixes the build issues with `dev` thanks to the hard work done in #192 #193 #181 . If not, i guess this PR will get longer and more interesting!