### PR TITLE
Don't run `test-vrl2csv` on R-universe ("CRAN")

### DIFF
--- a/tests/testthat/test-vrl2csv.r
+++ b/tests/testthat/test-vrl2csv.r
@@ -26,6 +26,7 @@ vrl_to_tempdir <- function(test_dir) {
 # Check csv from one VRL in dir with space in name
 test_that("one vrl gives expected result", {
   skip_on_ci()
+  skip_on_cran()
 
   vrl_loc <- vrl_to_tempdir("test")
 
@@ -102,6 +103,7 @@ test_that("one vrl gives expected result", {
 
 test_that("one vrl in dir with space in name gives expected result", {
   skip_on_ci()
+  skip_on_cran()
 
   vrl_loc <- vrl_to_tempdir("test path with spaces")
 


### PR DESCRIPTION
R-universe runs tests as CRAN and doesn't flag as on CI for some reason (@jdpye I was wrong in my note in #197). Adding `skip_on_cran` will skip these tests, which require `vue.exe`.

Test errors which prevent R-universe build on Windows and Mac:
https://github.com/r-universe/mhpob/actions/runs/7844599751/job/21407337477#step:5:1453
https://github.com/r-universe/mhpob/actions/runs/7844599751/job/21407336870#step:5:1373

Proof that `skip_on_cran` skips on R-universe ([`expect_snapshot` is skipped on CRAN by default](https://r-pkgs.org/testing-basics.html#sec-snapshot-tests)):
https://github.com/r-universe/mhpob/actions/runs/7844599751/job/21407337477#step:5:1435