### PR TITLE
Remove dependency on `units`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,6 @@ Imports:
 		sp,
 		tibble,
 		tidyr,
-		units,
 		zip
 Suggests: 
 		gganimate,

--- a/R/vis-make_transition3.r
+++ b/R/vis-make_transition3.r
@@ -193,7 +193,7 @@ make_transition3 <- function(poly, res = c(0.1, 0.1), receiver_points = NULL, ep
     recs_gl <- sf::st_transform(receiver_points, crs = epsg)
 
     # determine shortest distance from receiver to water polygon
-    dist_rec <- units::drop_units(sf::st_distance(recs_gl, poly_gl))
+    dist_rec <- as.matrix(sf::st_distance(recs_gl, poly_gl))
     recs_gl$rec_water_dist <- apply(dist_rec, 1, "min")
 
     # extract rec_water_dist > 0

--- a/man/summarize_detections.Rd
+++ b/man/summarize_detections.Rd
@@ -137,60 +137,69 @@ the output summary.
 }
 \examples{
 
-#get path to example detection file
- det_file <- system.file("extdata", "walleye_detections.csv",
-   package = "glatos")
- det <- read_glatos_detections(det_file)
- 
- #Basic summaries
- 
- # by animal
- ds <- summarize_detections(det)
- 
- # by location 
- ds <- summarize_detections(det, summ_type = "location")
- 
- # by animal and location
- ds <- summarize_detections(det, summ_type = "both")
- 
- 
- #Include user-defined location_col
- 
- # by animal
- det$some_place <- ifelse(grepl("^S", det$glatos_array), "s", "not_s")
- 
- ds <- summarize_detections(det, location_col = "some_place")
- 
- # by location 
- ds <- summarize_detections(det, location_col = "some_place", 
-                            summ_type = "location")
- 
- # by animal and location
- ds <- summarize_detections(det, location_col = "some_place", 
-                            summ_type = "both")  
-                            
-                            
- #Include locations where no animals detected
- 
- #get example receiver data
- rec_file <- system.file("extdata", "sample_receivers.csv",
-   package = "glatos")
- rec <- read_glatos_receivers(rec_file) 
- 
- ds <- summarize_detections(det, receiver_locs = rec, summ_type = "location")
- 
- 
- #Include animals that were not detected
- #get example animal data from walleye workbook
- wb_file <- system.file("extdata", "walleye_workbook.xlsm",
-   package = "glatos")
- wb <- read_glatos_workbook(wb_file) 
- 
- ds <- summarize_detections(det, animals = wb$animals, summ_type = "animal")
- 
- #Include by animals and locations that were not detected
- ds <- summarize_detections(det, receiver_locs = rec, animals = wb$animals, 
-   summ_type = "both")
+# get path to example detection file
+det_file <- system.file("extdata", "walleye_detections.csv",
+  package = "glatos"
+)
+det <- read_glatos_detections(det_file)
+
+# Basic summaries
+
+# by animal
+ds <- summarize_detections(det)
+
+# by location
+ds <- summarize_detections(det, summ_type = "location")
+
+# by animal and location
+ds <- summarize_detections(det, summ_type = "both")
+
+
+# Include user-defined location_col
+
+# by animal
+det$some_place <- ifelse(grepl("^S", det$glatos_array), "s", "not_s")
+
+ds <- summarize_detections(det, location_col = "some_place")
+
+# by location
+ds <- summarize_detections(det,
+  location_col = "some_place",
+  summ_type = "location"
+)
+
+# by animal and location
+ds <- summarize_detections(det,
+  location_col = "some_place",
+  summ_type = "both"
+)
+
+
+# Include locations where no animals detected
+
+# get example receiver data
+rec_file <- system.file("extdata", "sample_receivers.csv",
+  package = "glatos"
+)
+rec <- read_glatos_receivers(rec_file)
+
+ds <- summarize_detections(det, receiver_locs = rec, summ_type = "location")
+
+
+# Include animals that were not detected
+# get example animal data from walleye workbook
+wb_file <- system.file("extdata", "walleye_workbook.xlsm",
+  package = "glatos"
+)
+wb <- read_glatos_workbook(wb_file)
+
+ds <- summarize_detections(det, animals = wb$animals, summ_type = "animal")
+
+# Include by animals and locations that were not detected
+ds <- summarize_detections(det,
+  receiver_locs = rec, animals = wb$animals,
+  summ_type = "both"
+)
 
 }
 \author{


### PR DESCRIPTION
Remove dependency on `units` introduced in a50334abe9ef813b2287bfea8f0371cf819ef36c. The same outcome as `units::drop_units` can be done by coercing to a matrix. Addresses one part of #122.

Running the examples in `make_transition3` with and without `units::drop_units` result in identical objects:
```
> identical(ex1, ex1_nounits)
[1] TRUE
> identical(ex2, ex2_nounits)
[1] TRUE
> identical(ex3, ex3_nounits)
[1] TRUE
```

This PR gets `glatos` down to 20 explicit dependencies, which clears the R CMD check dependency note:
  - before: https://github.com/ocean-tracking-network/glatos/actions/runs/8193178738/job/22406314930?pr=223#step:6:66
  - now clear: https://github.com/ocean-tracking-network/glatos/actions/runs/9068760018/job/24916782875?pr=229#step:6:66

Current R CMD check failure is due to a floating point issue on macOS which will be fixed with acceptance of #228 