### PR TITLE
Add R CMD CHECK for minimum R version (3.5.0)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,6 +23,9 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - {os: macos-latest,   r: '3.5.0'}
+          - {os: windows-latest, r: '3.5.0'}
+          - {os: ubuntu-latest,   r: '3.5.0'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`glatos` [depends on R version 3.5.0 or greater](https://github.com/ocean-tracking-network/glatos/blob/main/DESCRIPTION#L7). This PR runs on R v3.5.0, released April 23, 2018, to confirm that any changes to the package will, in fact, run.