### PR TITLE
Read zipped OTN detection extracts

### DIFF
--- a/R/load-read_otn_detections.r
+++ b/R/load-read_otn_detections.r
@@ -47,12 +47,16 @@ read_otn_detections <- function(det_file) {
   if (tools::file_ext(det_file) == "zip" && nrow(zip::zip_list(det_file)) > 1) {
     td <- tempdir()
 
-    zip::unzip(det_file, exdir = file.path(td, det_file))
+    zip::unzip(
+      det_file,
+      exdir = file.path(td, tools::file_path_sans_ext(basename(det_file)))
+    )
     det_file <- list.files(
-      file.path(td, det_file),
+      file.path(td, tools::file_path_sans_ext(basename(det_file))),
       pattern = "\\.csv$",
       full.names = TRUE
     )
+    det_file <- normalizePath(det_file)
   }
 
   # read data, suppressWarnings because some columns could be missing

--- a/R/load-read_otn_detections.r
+++ b/R/load-read_otn_detections.r
@@ -39,14 +39,35 @@ read_otn_detections <- function(det_file) {
   date_cols <- which(col_classes == "Date")
   col_classes[c(timestamp_cols, date_cols)] <- "character"
 
+  # Check if file is zipped
+  # `data.table::fread` can handle zipped CSVs if they are the only file in the
+  #   directory. If there are multiple files, they need to be unzipped first.
+  #   This code assumes that there is only one CSV within the zipped directory.
+  #   The other file would be "data_description.txt"
+  if (tools::file_ext(det_file) == "zip" && nrow(zip::zip_list(det_file)) > 1) {
+    td <- tempdir()
+
+    zip::unzip(det_file, exdir = file.path(td, det_file))
+    det_file <- list.files(
+      file.path(td, det_file),
+      pattern = "\\.csv$",
+      full.names = TRUE
+    )
+  }
+
   # read data, suppressWarnings because some columns could be missing
-  dtc <- suppressWarnings(data.table::fread(det_file,
-    sep = ",", colClasses = col_classes,
+  dtc <- suppressWarnings(data.table::fread(
+    det_file,
+    sep = ",",
+    colClasses = col_classes,
     na.strings = c("", "NA")
   ))
   # This check is for non-matched detection extracts. They are missing some required columns, this attempts to create them.
   # More info on OTN detection extracts here: https://members.oceantrack.org/data/otn-detection-extract-documentation-matched-to-animals
-  if (all(otn_detection_schema_min_columns %in% colnames(dtc)) && !all(otn_detection_schema$name %in% colnames(dtc))) {
+  if (
+    all(otn_detection_schema_min_columns %in% colnames(dtc)) &&
+      !all(otn_detection_schema$name %in% colnames(dtc))
+  ) {
     dtc$commonname <- "Unknown"
     dtc$receiver_group <- substr(dtc$station, 1, nchar(dtc$station) - 3)
     dtc$receiver <- dtc$collectornumber
@@ -55,26 +76,46 @@ read_otn_detections <- function(det_file) {
   }
   # coerce timestamps to POSIXct
   for (j in timestamp_cols) {
-    data.table::set(dtc,
+    data.table::set(
+      dtc,
       j = otn_detection_schema$name[j],
       value = lubridate::fast_strptime(
         dtc[[otn_detection_schema$name[j]]],
-        format = "%Y-%m-%d %H:%M:%S", tz = "UTC", lt = FALSE
+        format = "%Y-%m-%d %H:%M:%S",
+        tz = "UTC",
+        lt = FALSE
       )
     )
   }
   # coerce dates to date
   for (j in date_cols) {
-    data.table::set(dtc, j = otn_detection_schema$name[j], value = ifelse(dtc[[otn_detection_schema$name[j]]] == "", NA, dtc[[otn_detection_schema$name[j]]]))
-    data.table::set(dtc, j = otn_detection_schema$name[j], value = as.Date(dtc[[otn_detection_schema$name[j]]]))
+    data.table::set(
+      dtc,
+      j = otn_detection_schema$name[j],
+      value = ifelse(
+        dtc[[otn_detection_schema$name[j]]] == "",
+        NA,
+        dtc[[otn_detection_schema$name[j]]]
+      )
+    )
+    data.table::set(
+      dtc,
+      j = otn_detection_schema$name[j],
+      value = as.Date(dtc[[otn_detection_schema$name[j]]])
+    )
   }
-  data.table::setnames(dtc, old = otn_detection_schema$name, new = otn_detection_schema$mapping)
+  data.table::setnames(
+    dtc,
+    old = otn_detection_schema$name,
+    new = otn_detection_schema$mapping
+  )
   dtc <- glatos_detections(dtc)
   return(dtc)
 }
 
 get_codemap <- function(x) {
-  sapply(x,
+  sapply(
+    x,
     FUN = function(.) {
       x0 <- unlist(strsplit(., "-"))
       return(paste0(x0[1:2], collapse = "-"))

--- a/tests/testthat/test-read_otn_detections.r
+++ b/tests/testthat/test-read_otn_detections.r
@@ -14,3 +14,52 @@ test_that("blue_shark_detections gives expected result", {
   expect_s3_class(bsd, "glatos_detections")
   expect_s3_class(bsd, "data.frame")
 })
+
+test_that("handles zipped directory with one file", {
+  bsd_file <- system.file(
+    "extdata",
+    "blue_shark_detections.csv",
+    package = "glatos"
+  )
+
+  td <- file.path(tempdir(), "ziptest.zip")
+  zip::zip(td, bsd_file, mode = "cherry-pick")
+
+  bsd <- read_otn_detections(td)
+
+  # Check if expected and actual results are the same
+  expect_equal(bsd, blue_shark_detections)
+
+  expect_s3_class(bsd, "glatos_detections")
+  expect_s3_class(bsd, "data.frame")
+
+  unlink(td, recursive = TRUE)
+})
+
+test_that("handles zipped directory with multiple files", {
+  bsd_file <- system.file(
+    "extdata",
+    "blue_shark_detections.csv",
+    package = "glatos"
+  )
+
+  td <- file.path(tempdir(), "ziptest.zip")
+  temp_txt <- file.path(tempdir(), "data_description.txt")
+  file.create(temp_txt)
+  zip::zip(
+    td,
+    c(bsd_file, temp_txt),
+    mode = "cherry-pick"
+  )
+
+  bsd <- read_otn_detections(td)
+
+  # Check if expected and actual results are the same
+  expect_equal(bsd, blue_shark_detections)
+
+  expect_s3_class(bsd, "glatos_detections")
+  expect_s3_class(bsd, "data.frame")
+
+  unlink(td, recursive = TRUE)
+  unlink(temp_txt)
+})


### PR DESCRIPTION
Closes #262. Pertinent changes are lines 42-56 in `R/load-read_otn_detections.R`, the rest is exactly the same but has just been automatically formatted.

Lets `read_otn_detections()` handle the zipped CSV format of OTN data extracts. `data.table::fread` can automatically handle zipped folders that have one file in them, but the folder needs to be unzipped first if there are multiple files -- this is usually the case as OTN ships a "data_description.txt" in the zip.

Adds tests for the new behavior.