### PR TITLE
Explicitly call data from the glatos package

### DIFF
--- a/R/load-read_vdat_csv.r
+++ b/R/load-read_vdat_csv.r
@@ -179,7 +179,8 @@ read_vdat_csv <- function(src, record_types = NULL, show_progress = FALSE) {
   )
 
   # Identify record type of each row
-  vdat_txt[,
+  vdat_txt[
+    ,
     record_type := data.table::fread(
       file = src,
       skip = 2,

--- a/R/vis-detection_bubble_plot.r
+++ b/R/vis-detection_bubble_plot.r
@@ -114,17 +114,16 @@
 #' @export
 
 detection_bubble_plot <- function(
-  det,
-  location_col = "glatos_array",
-  receiver_locs = NULL,
-  map = NULL,
-  out_file = NULL,
-  background_ylim = c(41.3, 49.0),
-  background_xlim = c(-92.45, -75.87),
-  symbol_radius = 1,
-  col_grad = c("white", "red"),
-  scale_loc = NULL
-) {
+    det,
+    location_col = "glatos_array",
+    receiver_locs = NULL,
+    map = NULL,
+    out_file = NULL,
+    background_ylim = c(41.3, 49.0),
+    background_xlim = c(-92.45, -75.87),
+    symbol_radius = 1,
+    col_grad = c("white", "red"),
+    scale_loc = NULL) {
   #  Declare global variables for NSE & R CMD check
   great_lakes_polygon <- NULL
 

--- a/R/vis-detection_bubble_plot.r
+++ b/R/vis-detection_bubble_plot.r
@@ -113,24 +113,29 @@
 #'
 #' @export
 
-
-detection_bubble_plot <- function(det, location_col = "glatos_array",
-                                  receiver_locs = NULL,
-                                  map = NULL,
-                                  out_file = NULL,
-                                  background_ylim = c(41.3, 49.0),
-                                  background_xlim = c(-92.45, -75.87),
-                                  symbol_radius = 1,
-                                  col_grad = c("white", "red"),
-                                  scale_loc = NULL) {
+detection_bubble_plot <- function(
+  det,
+  location_col = "glatos_array",
+  receiver_locs = NULL,
+  map = NULL,
+  out_file = NULL,
+  background_ylim = c(41.3, 49.0),
+  background_xlim = c(-92.45, -75.87),
+  symbol_radius = 1,
+  col_grad = c("white", "red"),
+  scale_loc = NULL
+) {
   #  Declare global variables for NSE & R CMD check
   great_lakes_polygon <- NULL
 
   # Check that the specified columns appear in the det data frame
   missingCols <- setdiff(
     c(
-      "animal_id", "detection_timestamp_utc",
-      "deploy_lat", "deploy_long", location_col
+      "animal_id",
+      "detection_timestamp_utc",
+      "deploy_lat",
+      "deploy_long",
+      location_col
     ),
     names(det)
   )
@@ -138,14 +143,12 @@ detection_bubble_plot <- function(det, location_col = "glatos_array",
     stop(
       paste0(
         "det is missing the following ",
-        "column(s):\n", paste0("       '", missingCols, "'",
-          collapse = "\n"
-        )
+        "column(s):\n",
+        paste0("       '", missingCols, "'", collapse = "\n")
       ),
       call. = FALSE
     )
   }
-
 
   # convert sp to sf
   if (!is.null(map) & inherits(map, "Spatial")) {
@@ -166,21 +169,29 @@ detection_bubble_plot <- function(det, location_col = "glatos_array",
   }
 
   if (is.null(map)) {
-    utils::data("great_lakes_polygon", envir = environment())
+    utils::data(
+      "great_lakes_polygon",
+      envir = environment(),
+      package = "glatos"
+    )
     map <- great_lakes_polygon
     rm(great_lakes_polygon)
   } # example in glatos package (sf object)
 
   # Check that timestamp is of class 'POSIXct'
   if (!("POSIXct" %in% class(det$detection_timestamp_utc))) {
-    stop(paste0("Column detection_timestamp_utc in det data frame must be of
-                class 'POSIXct'."),
+    stop(
+      paste0(
+        "Column detection_timestamp_utc in det data frame must be of
+                class 'POSIXct'."
+      ),
       call. = FALSE
     )
   }
 
   # Call glatos::detection_summary to create summary data.
-  det_summ <- glatos::summarize_detections(det,
+  det_summ <- glatos::summarize_detections(
+    det,
     location_col = location_col,
     receiver_locs = receiver_locs,
     summ_type = "location"
@@ -192,14 +203,22 @@ detection_bubble_plot <- function(det, location_col = "glatos_array",
   det_summ <- det_summ[order(det_summ$num_fish), ]
 
   # Create labs with degrees symbol for plots
-  xlabs <- round(seq(
-    from = background_xlim[1], to = background_xlim[2],
-    length.out = 5
-  ), 2)
-  ylabs <- round(seq(
-    from = background_ylim[1], to = background_ylim[2],
-    length.out = 5
-  ), 2)
+  xlabs <- round(
+    seq(
+      from = background_xlim[1],
+      to = background_xlim[2],
+      length.out = 5
+    ),
+    2
+  )
+  ylabs <- round(
+    seq(
+      from = background_ylim[1],
+      to = background_ylim[2],
+      length.out = 5
+    ),
+    2
+  )
 
   # Define the color palette used to color-code the bubbles
   color <- c(colorRampPalette(col_grad)(101))
@@ -207,12 +226,18 @@ detection_bubble_plot <- function(det, location_col = "glatos_array",
   # Calculate great circle distance in meters of x and y limits.
   # needed to determine aspect ratio of the output
   linear_x <- geodist::geodist_vec(
-    x1 = background_xlim[1], y1 = background_ylim[1],
-    x2 = background_xlim[2], y2 = background_ylim[1], measure = "haversine"
+    x1 = background_xlim[1],
+    y1 = background_ylim[1],
+    x2 = background_xlim[2],
+    y2 = background_ylim[1],
+    measure = "haversine"
   )
   linear_y <- geodist::geodist_vec(
-    x1 = background_xlim[1], y1 = background_ylim[1],
-    x2 = background_xlim[1], y2 = background_ylim[2], measure = "haversine"
+    x1 = background_xlim[1],
+    y1 = background_ylim[1],
+    x2 = background_xlim[1],
+    y2 = background_ylim[2],
+    measure = "haversine"
   )
 
   # aspect ratio of image
@@ -224,7 +249,8 @@ detection_bubble_plot <- function(det, location_col = "glatos_array",
   # check file extension is supported
   ext_supp <- c(NA, "png", "jpeg", "png", "bmp", "tiff")
   if (!(tolower(file_type) %in% ext_supp)) {
-    stop(paste0("Image type '", file_type, "' is not supported."),
+    stop(
+      paste0("Image type '", file_type, "' is not supported."),
       call. = FALSE
     )
   }
@@ -250,33 +276,42 @@ detection_bubble_plot <- function(det, location_col = "glatos_array",
   par(mar = c(1, 0, 0, 2), oma = c(3, 5, 1, 0))
 
   # Plot background image
-  plot(sf::st_geometry(map),
-    xlim = background_xlim, ylim = background_ylim, axes = T,
-    xaxs = "i", lwd = 1.5, xaxt = "n", yaxt = "n", col = "White",
+  plot(
+    sf::st_geometry(map),
+    xlim = background_xlim,
+    ylim = background_ylim,
+    axes = T,
+    xaxs = "i",
+    lwd = 1.5,
+    xaxt = "n",
+    yaxt = "n",
+    col = "White",
     bg = "WhiteSmoke"
   )
 
   # Plot the bubbles
-  symbols(det_summ$mean_lon, det_summ$mean_lat,
+  symbols(
+    det_summ$mean_lon,
+    det_summ$mean_lat,
     circles = rep(
       (background_xlim[2] -
-        background_xlim[1]) * symbol_radius / 100,
+        background_xlim[1]) *
+        symbol_radius /
+        100,
       length(det_summ$mean_lon)
     ),
-    add = T, inches = FALSE,
-    bg = color[round(det_summ$num_fish
-      / max(det_summ$num_fish) * 100, 0) + 1],
-    fg = "black", lwd = 3
+    add = T,
+    inches = FALSE,
+    bg = color[round(det_summ$num_fish / max(det_summ$num_fish) * 100, 0) + 1],
+    fg = "black",
+    lwd = 3
   )
 
   # Add 'X' to bubbles with no detections
   if (any(det_summ$num_fish == 0)) {
     with(
       det_summ[det_summ$num_fish == 0, ],
-      text(mean_lon, mean_lat,
-        "X",
-        cex = 0.6 * symbol_radius
-      )
+      text(mean_lon, mean_lat, "X", cex = 0.6 * symbol_radius)
     )
   }
 
@@ -291,33 +326,55 @@ detection_bubble_plot <- function(det, location_col = "glatos_array",
   }
   # Add color legend
   # explore options for doing this without an extra plotrix package https://stackoverflow.com/questions/13355176/gradient-legend-in-base
-  plotrix::color.legend(scale_loc[1], scale_loc[2], scale_loc[3], scale_loc[4],
-    paste0(" ", round(
-      seq(from = 1, to = max(det_summ$num_fish), length.out = 6),
-      0
-    )), color,
-    gradient = "y", family = "sans", cex = 0.75, align = "rb"
+  plotrix::color.legend(
+    scale_loc[1],
+    scale_loc[2],
+    scale_loc[3],
+    scale_loc[4],
+    paste0(
+      " ",
+      round(
+        seq(from = 1, to = max(det_summ$num_fish), length.out = 6),
+        0
+      )
+    ),
+    color,
+    gradient = "y",
+    family = "sans",
+    cex = 0.75,
+    align = "rb"
   )
 
   # Add x-axis and title
-  axis(1, at = xlabs, labels = paste0(format(xlabs, 4), intToUtf8(176)), cex.axis = 1)
+  axis(
+    1,
+    at = xlabs,
+    labels = paste0(format(xlabs, 4), intToUtf8(176)),
+    cex.axis = 1
+  )
   mtext("Longitude", side = 1, line = 2.5, cex = 1)
 
   # Add y-axis and title
-  axis(2,
-    at = ylabs, labels = paste0(format(ylabs, 4), intToUtf8(176)), cex.axis = 1,
+  axis(
+    2,
+    at = ylabs,
+    labels = paste0(format(ylabs, 4), intToUtf8(176)),
+    cex.axis = 1,
     las = 1
   )
   mtext("Latitude", side = 2, line = 4, cex = 1)
 
   box()
 
-  if (!is.na(file_type)) dev.off() # Close plot device
+  if (!is.na(file_type)) {
+    dev.off()
+  } # Close plot device
 
   if (!is.na(file_type)) {
     message(paste0(
       "Image files were written to the following directory:\n",
-      getwd(), "\n"
+      getwd(),
+      "\n"
     ))
   }
 

--- a/R/vis-make_frames.r
+++ b/R/vis-make_frames.r
@@ -207,19 +207,29 @@
 #'
 #' @export
 
-make_frames <- function(proc_obj, recs = NULL, out_dir = getwd(),
-                        background_ylim = c(41.3, 49.0),
-                        background_xlim = c(-92.45, -75.87),
-                        show_interpolated = TRUE, tail_dur = 0, animate = TRUE,
-                        ani_name = "animation.mp4", frame_delete = FALSE,
-                        overwrite = FALSE, preview = FALSE,
-                        bg_map = NULL, show_progress = TRUE, ...) {
+make_frames <- function(
+  proc_obj,
+  recs = NULL,
+  out_dir = getwd(),
+  background_ylim = c(41.3, 49.0),
+  background_xlim = c(-92.45, -75.87),
+  show_interpolated = TRUE,
+  tail_dur = 0,
+  animate = TRUE,
+  ani_name = "animation.mp4",
+  frame_delete = FALSE,
+  overwrite = FALSE,
+  preview = FALSE,
+  bg_map = NULL,
+  show_progress = TRUE,
+  ...
+) {
   # NOTE: As of glatos v 0.4.1, the package no longer uses the external program ffmpeg.  Input argument 'ffmpeg' has been removed"
 
   #  Declare global variables for NSE & R CMD check
   row_in <- recover_date_time <- grp <- bin_timestamp <- t_end <- grp_num <-
     f_name <- animal_id <- record_type <- latitude <- longitude <-
-    deploy_date_time <- great_lakes_polygon <- NULL
+      deploy_date_time <- great_lakes_polygon <- NULL
 
   # expand path to animation output file
   # - place in same file as images (out_dir) if none specified
@@ -237,7 +247,8 @@ make_frames <- function(proc_obj, recs = NULL, out_dir = getwd(),
 
   # if overwrite = FALSE, check if animation output file exists
   if (!overwrite & file.exists(ani_name)) {
-    stop("Operation aborted ",
+    stop(
+      "Operation aborted ",
       "because output video file ",
       "exists and 'overwrite = ",
       "FALSE'.",
@@ -250,7 +261,6 @@ make_frames <- function(proc_obj, recs = NULL, out_dir = getwd(),
 
   # make column to identify original row to join with option plot arguments
   work_proc_obj[, row_in := 1:.N]
-
 
   # capture optional plot arguments passed via ellipses
   #  and add original row indices to join on both
@@ -269,25 +279,36 @@ make_frames <- function(proc_obj, recs = NULL, out_dir = getwd(),
   timeslider_inargs <- inargs[grepl("^timeslider\\.", names(inargs))]
 
   # identify dtc input arguments
-  dtc_inarg_names <- setdiff(names(inargs), c(
-    names(par_inargs),
-    names(rcv_inargs),
-    names(timeline_inargs),
-    names(timeslider_inargs)
-  ))
+  dtc_inarg_names <- setdiff(
+    names(inargs),
+    c(
+      names(par_inargs),
+      names(rcv_inargs),
+      names(timeline_inargs),
+      names(timeslider_inargs)
+    )
+  )
 
   # identify and subset detection point arguments
   dtc_inargs <- inargs[dtc_inarg_names]
   # strip argument names
   names(par_inargs) <- gsub("^par\\.", "", names(par_inargs))
   names(timeline_inargs) <- gsub("^timeline\\.", "", names(timeline_inargs))
-  names(timeslider_inargs) <- gsub("^timeslider\\.", "", names(timeslider_inargs))
+  names(timeslider_inargs) <- gsub(
+    "^timeslider\\.",
+    "",
+    names(timeslider_inargs)
+  )
   names(rcv_inargs) <- gsub("^recs\\.", "", names(rcv_inargs))
 
   # update from ...
-  if (length(rcv_inargs) > 0) rcv_args[names(rcv_inargs)] <- rcv_inargs
+  if (length(rcv_inargs) > 0) {
+    rcv_args[names(rcv_inargs)] <- rcv_inargs
+  }
   # update from ...
-  if (length(dtc_inargs) > 0) dtc_args[names(dtc_inargs)] <- dtc_inargs
+  if (length(dtc_inargs) > 0) {
+    dtc_args[names(dtc_inargs)] <- dtc_inargs
+  }
 
   # expand single rcv_args elements to equal number of rows in recs
   if (!is.null(recs)) {
@@ -321,7 +342,6 @@ make_frames <- function(proc_obj, recs = NULL, out_dir = getwd(),
   dtc_args <- data.table::as.data.table(dtc_args)
   dtc_args[, row_in := 1:.N]
 
-
   # set recs to data.table and remove receivers not recovered
   if (!is.null(recs)) {
     recs <- data.table::as.data.table(recs)
@@ -331,20 +351,26 @@ make_frames <- function(proc_obj, recs = NULL, out_dir = getwd(),
 
     # Remove receivers not recovered (records with NA in recover_date_time)
     data.table::setkey(recs, recover_date_time)
-    recs <- recs[!list(NA_real_), c(
-      "station", "deploy_lat",
-      "deploy_long", "deploy_date_time",
-      "recover_date_time", "row_in"
-    )]
+    recs <- recs[
+      !list(NA_real_),
+      c(
+        "station",
+        "deploy_lat",
+        "deploy_long",
+        "deploy_date_time",
+        "recover_date_time",
+        "row_in"
+      )
+    ]
   }
 
-
   # Make output directory if it does not already exist
-  if (!dir.exists(out_dir)) dir.create(out_dir)
+  if (!dir.exists(out_dir)) {
+    dir.create(out_dir)
+  }
 
   # extract time sequence for plotting
   t_seq <- unique(work_proc_obj$bin_timestamp)
-
 
   # make tails if needed
   if (tail_dur == 0) {
@@ -353,32 +379,44 @@ make_frames <- function(proc_obj, recs = NULL, out_dir = getwd(),
   } else {
     # make tail groups if needed
     dur <- work_proc_obj[, .(t_seq = sort(unique(bin_timestamp)))]
-    dur[, c("t_end", "t_grp") :=
-      list(
-        data.table::shift(t_seq,
-          type = "lag",
-          fill = min(t_seq), n = tail_dur
-        ),
+    dur[,
+      c("t_end", "t_grp") := list(
+        data.table::shift(t_seq, type = "lag", fill = min(t_seq), n = tail_dur),
         1:nrow(dur)
-      )]
+      )
+    ]
 
     # group obs for tails
     work_proc_obj[, t_end := bin_timestamp]
     data.table::setkey(dur, t_end, t_seq)
 
     # merge by overlap
-    work_proc_obj <- data.table::foverlaps(work_proc_obj, dur,
+    work_proc_obj <- data.table::foverlaps(
+      work_proc_obj,
+      dur,
       type = "within",
-      nomatch = 0L, by.x = c("bin_timestamp", "t_end")
+      nomatch = 0L,
+      by.x = c("bin_timestamp", "t_end")
     )
     work_proc_obj <- work_proc_obj[, c(
-      "animal_id", "t_seq", "latitude",
-      "longitude", "record_type", "row_in"
+      "animal_id",
+      "t_seq",
+      "latitude",
+      "longitude",
+      "record_type",
+      "row_in"
     )]
-    data.table::setnames(work_proc_obj, c(
-      "animal_id", "bin_timestamp", "latitude",
-      "longitude", "record_type", "row_in"
-    ))
+    data.table::setnames(
+      work_proc_obj,
+      c(
+        "animal_id",
+        "bin_timestamp",
+        "latitude",
+        "longitude",
+        "record_type",
+        "row_in"
+      )
+    )
     work_proc_obj[, grp := bin_timestamp]
   }
 
@@ -398,8 +436,13 @@ make_frames <- function(proc_obj, recs = NULL, out_dir = getwd(),
   data.table::setkey(work_proc_obj, bin_timestamp, animal_id, record_type)
 
   # Load background (use example Great Lakes if null)
-  if (is.null(bg_map)) { # example in glatos package
-    utils::data("great_lakes_polygon", envir = environment())
+  if (is.null(bg_map)) {
+    # example in glatos package
+    utils::data(
+      "great_lakes_polygon",
+      envir = environment(),
+      package = "glatos"
+    )
     background <- great_lakes_polygon
     rm(great_lakes_polygon)
   } else {
@@ -444,8 +487,15 @@ make_frames <- function(proc_obj, recs = NULL, out_dir = getwd(),
   time_period <- range(work_proc_obj$bin_timestamp)
 
   # define custom plot function
-  cust_plot <- function(x, .time_period, .recs, .out_dir, .background,
-                        .background_xlim, .background_ylim) {
+  cust_plot <- function(
+    x,
+    .time_period,
+    .recs,
+    .out_dir,
+    .background,
+    .background_xlim,
+    .background_ylim
+  ) {
     # Calculate great circle distance in meters of x and y limits.
     # needed to determine aspect ratio of the output
 
@@ -478,9 +528,11 @@ make_frames <- function(proc_obj, recs = NULL, out_dir = getwd(),
     height <- trunc(2000 * figRatio)
 
     # plot GL outline and movement points
-    png(file.path(.out_dir, x$f_name[1]),
+    png(
+      file.path(.out_dir, x$f_name[1]),
       width = 2000,
-      height = ifelse(height %% 2 == 0, height, height + 1), units = "px",
+      height = ifelse(height %% 2 == 0, height, height + 1),
+      units = "px",
       pointsize = 22 * figRatio
     )
 
@@ -490,15 +542,21 @@ make_frames <- function(proc_obj, recs = NULL, out_dir = getwd(),
     # set defaults and apply if needed
     par_args <- list(oma = c(0, 0, 0, 0), mar = c(6, 0, 0, 0), xpd = FALSE)
     # update from defaults...
-    if (length(par_inargs) > 0) par_args[names(par_inargs)] <- par_inargs
+    if (length(par_inargs) > 0) {
+      par_args[names(par_inargs)] <- par_inargs
+    }
 
     do.call(par, par_args)
 
     # Note this call was changed to sf?
-    plot(sf::st_geometry(.background),
+    plot(
+      sf::st_geometry(.background),
       ylim = c(.background_ylim),
       xlim = c(.background_xlim),
-      axes = FALSE, lwd = 2 * figRatio, col = "white", bg = "gray74"
+      axes = FALSE,
+      lwd = 2 * figRatio,
+      col = "white",
+      bg = "gray74"
     )
 
     box(lwd = 3 * figRatio)
@@ -506,17 +564,22 @@ make_frames <- function(proc_obj, recs = NULL, out_dir = getwd(),
     # Add receiver locations
     if (!is.null(.recs)) {
       # extract receivers in the water during plot interval
-      sub_recs <- .recs[deploy_date_time <= x$bin_timestamp[1] &
-        (recover_date_time >= x$bin_timestamp[1] & !is.na(recover_date_time))]
+      sub_recs <- .recs[
+        deploy_date_time <= x$bin_timestamp[1] &
+          (recover_date_time >= x$bin_timestamp[1] & !is.na(recover_date_time))
+      ]
 
       # get optional plot arguments that correspond with sub_recs
       sub_rcv_args <- rcv_args[match(sub_recs$row_in, rcv_args$row_in), ]
 
       # plot receivers; not do.call to include optional input arguments
-      do.call(points, c(
-        list(x = sub_recs$deploy_long, y = sub_recs$deploy_lat),
-        sub_rcv_args[, !"row_in", with = FALSE]
-      ))
+      do.call(
+        points,
+        c(
+          list(x = sub_recs$deploy_long, y = sub_recs$deploy_lat),
+          sub_rcv_args[, !"row_in", with = FALSE]
+        )
+      )
     }
 
     # Add timeline
@@ -534,20 +597,29 @@ make_frames <- function(proc_obj, recs = NULL, out_dir = getwd(),
     time_dur <- diff(as.numeric(.time_period))
 
     # Add labels to timeline
-    labels <- seq(as.POSIXct(format(min(.time_period), "%Y-%m-%d")),
+    labels <- seq(
+      as.POSIXct(format(min(.time_period), "%Y-%m-%d")),
       as.POSIXct(format(max(.time_period), "%Y-%m-%d")),
       length.out = 5
     )
     labels_ticks <- as.POSIXct(format(labels, "%Y-%m-%d"), tz = "GMT")
-    ptime <- (as.numeric(labels_ticks) - as.numeric(min(.time_period))) / time_dur
+    ptime <- (as.numeric(labels_ticks) - as.numeric(min(.time_period))) /
+      time_dur
     labels_x <- timeline_x[1] + (diff(timeline_x) * ptime)
 
     # set defaults and apply if needed
     timeline_args <- list(
-      side = 1, at = labels_x, pos = timeline_y[1],
-      labels = format(labels, "%Y-%m-%d"), col = "grey70",
-      lwd = 20 * figRatio, lend = 0, lwd.ticks = NA,
-      col.ticks = 1, cex.axis = 2, padj = 0.5
+      side = 1,
+      at = labels_x,
+      pos = timeline_y[1],
+      labels = format(labels, "%Y-%m-%d"),
+      col = "grey70",
+      lwd = 20 * figRatio,
+      lend = 0,
+      lwd.ticks = NA,
+      col.ticks = 1,
+      cex.axis = 2,
+      padj = 0.5
     )
 
     # update from ...
@@ -558,9 +630,9 @@ make_frames <- function(proc_obj, recs = NULL, out_dir = getwd(),
 
     do.call(axis, timeline_args)
 
-
     # Update timeline
-    ptime <- (as.numeric(x[1, "grp"]) - as.numeric(min(.time_period))) / time_dur
+    ptime <- (as.numeric(x[1, "grp"]) - as.numeric(min(.time_period))) /
+      time_dur
 
     # Proportion of timeline elapsed
     timeline_x_i <- timeline_x[1] + diff(timeline_x) * ptime
@@ -568,7 +640,10 @@ make_frames <- function(proc_obj, recs = NULL, out_dir = getwd(),
     # set defaults and apply if needed
     timeslider_args <- list(
       pch = 21,
-      cex = 2, bg = "grey40", col = "grey20", lwd = 1
+      cex = 2,
+      bg = "grey40",
+      col = "grey20",
+      lwd = 1
     )
 
     # update from ...
@@ -578,27 +653,31 @@ make_frames <- function(proc_obj, recs = NULL, out_dir = getwd(),
     }
 
     # Plot slider along timeline at appropriate location
-    do.call(points, c(
-      list(x = timeline_x_i, y = timeline_args$pos),
-      timeslider_args
-    ))
-
+    do.call(
+      points,
+      c(
+        list(x = timeline_x_i, y = timeline_args$pos),
+        timeslider_args
+      )
+    )
 
     # Add fish positions
     # get optional plot arguments that correspond with x
     sub_dtc_args <- dtc_args[match(x$row_in, dtc_args$row_in), ]
 
-    do.call(points, c(
-      list(x = x$longitude, y = x$latitude),
-      sub_dtc_args[, !"row_in", with = FALSE]
-    ))
+    do.call(
+      points,
+      c(
+        list(x = x$longitude, y = x$latitude),
+        sub_dtc_args[, !"row_in", with = FALSE]
+      )
+    )
 
     dev.off()
   }
 
   # order for plotting
   data.table::setkey(work_proc_obj, grp_num)
-
 
   if (preview) {
     grpn <- 1
@@ -609,9 +688,12 @@ make_frames <- function(proc_obj, recs = NULL, out_dir = getwd(),
   }
 
   # call cust_plot witin data.table
-  work_proc_obj[grp_num <= grpn,
+  work_proc_obj[
+    grp_num <= grpn,
     {
-      if (!preview & show_progress) setTxtProgressBar(pb, .GRP)
+      if (!preview & show_progress) {
+        setTxtProgressBar(pb, .GRP)
+      }
       cust_plot(
         x = .SD,
         .time_period = time_period,
@@ -624,15 +706,22 @@ make_frames <- function(proc_obj, recs = NULL, out_dir = getwd(),
     },
     by = grp,
     .SDcols = c(
-      "bin_timestamp", "longitude", "latitude",
-      "record_type", "f_name", "grp", "row_in"
+      "bin_timestamp",
+      "longitude",
+      "latitude",
+      "record_type",
+      "f_name",
+      "grp",
+      "row_in"
     )
   ]
 
   if (preview) {
     message("Preview frames written to\n ", out_dir)
   } else {
-    if (show_progress) close(pb)
+    if (show_progress) {
+      close(pb)
+    }
 
     if (animate) {
       make_video(input_dir = out_dir, output = ani_name, overwrite = overwrite)

--- a/R/vis-make_frames.r
+++ b/R/vis-make_frames.r
@@ -208,28 +208,27 @@
 #' @export
 
 make_frames <- function(
-  proc_obj,
-  recs = NULL,
-  out_dir = getwd(),
-  background_ylim = c(41.3, 49.0),
-  background_xlim = c(-92.45, -75.87),
-  show_interpolated = TRUE,
-  tail_dur = 0,
-  animate = TRUE,
-  ani_name = "animation.mp4",
-  frame_delete = FALSE,
-  overwrite = FALSE,
-  preview = FALSE,
-  bg_map = NULL,
-  show_progress = TRUE,
-  ...
-) {
+    proc_obj,
+    recs = NULL,
+    out_dir = getwd(),
+    background_ylim = c(41.3, 49.0),
+    background_xlim = c(-92.45, -75.87),
+    show_interpolated = TRUE,
+    tail_dur = 0,
+    animate = TRUE,
+    ani_name = "animation.mp4",
+    frame_delete = FALSE,
+    overwrite = FALSE,
+    preview = FALSE,
+    bg_map = NULL,
+    show_progress = TRUE,
+    ...) {
   # NOTE: As of glatos v 0.4.1, the package no longer uses the external program ffmpeg.  Input argument 'ffmpeg' has been removed"
 
   #  Declare global variables for NSE & R CMD check
   row_in <- recover_date_time <- grp <- bin_timestamp <- t_end <- grp_num <-
     f_name <- animal_id <- record_type <- latitude <- longitude <-
-      deploy_date_time <- great_lakes_polygon <- NULL
+    deploy_date_time <- great_lakes_polygon <- NULL
 
   # expand path to animation output file
   # - place in same file as images (out_dir) if none specified
@@ -379,7 +378,8 @@ make_frames <- function(
   } else {
     # make tail groups if needed
     dur <- work_proc_obj[, .(t_seq = sort(unique(bin_timestamp)))]
-    dur[,
+    dur[
+      ,
       c("t_end", "t_grp") := list(
         data.table::shift(t_seq, type = "lag", fill = min(t_seq), n = tail_dur),
         1:nrow(dur)
@@ -488,14 +488,13 @@ make_frames <- function(
 
   # define custom plot function
   cust_plot <- function(
-    x,
-    .time_period,
-    .recs,
-    .out_dir,
-    .background,
-    .background_xlim,
-    .background_ylim
-  ) {
+      x,
+      .time_period,
+      .recs,
+      .out_dir,
+      .background,
+      .background_xlim,
+      .background_ylim) {
     # Calculate great circle distance in meters of x and y limits.
     # needed to determine aspect ratio of the output
 


### PR DESCRIPTION
Closes #261 

When data is accessed within a function using `utils::data`, it will now look in the local installation of `glatos`. This allows using `glatos` functions without loading them into the namespace. I.e., `glatos::read_vdat_csv(csv_file)` will now work (line 222).

`utils::data(..., package = "glatos")`

I also updated `detection_bubble_plot` (line 172) and `make_frames` (line 439) in the same way. All other changes are just automatic formatting via the [Air formatter](https://www.tidyverse.org/blog/2025/02/air/).