### PR TITLE
Update readme

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,5 @@
 ^README-.*\.png$
 ^\.github$
 ^R/util-intern_pkg_man\.r$
+^\.positai$
+^\.claude$

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ doc
 /doc/
 /Meta/
 inst/doc
+.positai

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,8 +49,8 @@ Authors@R: c(
 License: GPL-2
 LazyLoad: yes
 LazyData: true
-RoxygenNote: 7.3.3
 VignetteBuilder: knitr
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 Config/testthat/edition: 3
+Config/roxygen2/version: 8.0.0

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -37,7 +37,7 @@ https://github.com/ocean-tracking-network/glatos/wiki/installation-instructions.
 
 1.  [`read_glatos_detections`](https://github.com/ocean-tracking-network/glatos/blob/main/R/load-read_glatos_detections.r) and [`read_otn_detections`](https://github.com/ocean-tracking-network/glatos/blob/main/R/load-read_otn_detections.r) provide fast data loading from standard GLATOS and OTN data files to a single structure that is compatible with other glatos functions.
 
-2.  [`read_glatos_receivers`](https://github.com/ocean-tracking-network/glatos/blob/main/R/load-read_glatos_receivers.r) and [`read_otn_deployments`](https://github.com/ocean-tracking-network/glatos/blob/main/R/load-read_otn_deployments.r) reads receiver location histories from standard GLATOS and OTN data files to a single structure that is compatible with other glatos functions.
+2.  [`read_glatos_receivers`](https://github.com/ocean-tracking-network/glatos/blob/main/R/load-read_glatos_receivers.r) and [`read_otn_deployments`](https://github.com/ocean-tracking-network/glatos/blob/main/R/load-read_otn_deployments.R) reads receiver location histories from standard GLATOS and OTN data files to a single structure that is compatible with other glatos functions.
 
 3.  [`read_glatos_workbook`](https://github.com/ocean-tracking-network/glatos/blob/main/R/load-read_glatos_workbook.r) reads project-specific receiver history and fish taggging and release data from a standard glatos workbook file.
 
@@ -45,7 +45,7 @@ https://github.com/ocean-tracking-network/glatos/wiki/installation-instructions.
 
 5.  [`real_sensor_values`](https://github.com/ocean-tracking-network/glatos/blob/main/R/proc-real_sensor_values.r) converts 'raw' transmitter sensor (e.g., depth, temperature) to 'real'-scale values (e.g., depth in meters) using transmitter specification data (e.g., from read_vemco_tag_specs).
 
-6. [`prepare_tag_sheet`](https://github.com/ocean-tracking-network/glatos/blob/main/R/load-prepare_tag_sheet.r) and [`prepare_deploy_sheet`](https://github.com/ocean-tracking-network/glatos/blob/main/R/load-prepare_deploy_sheet.r) load OTN metadata sheets for Tagging and Deployment of Receivers and formats them for converting to ATT Data.
+6. [`prepare_tag_sheet`](https://github.com/ocean-tracking-network/glatos/blob/main/R/load-prepare_tag_sheet.R) and [`prepare_deploy_sheet`](https://github.com/ocean-tracking-network/glatos/blob/main/R/load-prepare_deploy_sheet.R) load OTN metadata sheets for Tagging and Deployment of Receivers and formats them for converting to ATT Data.
 
 7. `vue_convert` and `vdat_convert` extracts data from proprietary receiver
 files (.vrl, .vdat) using Innovasea's VUE and VDAT software (packaged with
@@ -71,7 +71,7 @@ exported from Innovasea's VUE software.
 
 5.  [`residence_index`](https://github.com/ocean-tracking-network/glatos/blob/main/R/summ-residence_index.r) calculates the relative proportion of time spent at each location.
 
-6.  [`REI`](https://github.com/ocean-tracking-network/glatos/blob/main/R/REI.r) calculates the relative activity at each receiver based on number of unique 
+6.  `REI` calculates the relative activity at each receiver based on number of unique 
 species and individual animals.
 
 7.  `detection_range_model` for estimating detection range at which a certain 
@@ -85,7 +85,7 @@ software.
 
 2.  [`receiver_line_det_sim`](https://github.com/ocean-tracking-network/glatos/blob/main/R/sim-receiver_line_det_sim.r) simulates detection of acoustic-tagged fish crossing a receiver line (or single receiver). This is useful for determining optimal spacing of receviers in a line and tag specifications (e.g., delay).
 
-3.  [`crw_in_polygon`](https://github.com/ocean-tracking-network/glatos/blob/main/R/simutil-crw_in_polygon.r), [`transmit_along_path`](https://github.com/ocean-tracking-network/glatos/blob/main/R/sim-transmit_along_path.r), and [`detect_transmissions`](https://github.com/ocean-tracking-network/glatos/blob/main/R/sim-detect_transmissions.r) individually simulate random fish movement paths within a water body (*crw_in_polygon*: a random walk in a polygon), tag signal transmissions along those paths (*transmit_along_path*: time series and locations of transmissions based on tag specs), and detection of those transmittions by receivers in a user-defined receiver network (*detect_transmissions*: time series and locations of detections based on detection range curve). Collectively, these functions can be used to explore, compare, and contrast theoretical performance of a wide range of transmitter and receiver network designs.
+3.  `crw_in_polygon`, [`transmit_along_path`](https://github.com/ocean-tracking-network/glatos/blob/main/R/sim-transmit_along_path.r), and [`detect_transmissions`](https://github.com/ocean-tracking-network/glatos/blob/main/R/sim-detect_transmissions.r) individually simulate random fish movement paths within a water body (*crw_in_polygon*: a random walk in a polygon), tag signal transmissions along those paths (*transmit_along_path*: time series and locations of transmissions based on tag specs), and detection of those transmittions by receivers in a user-defined receiver network (*detect_transmissions*: time series and locations of detections based on detection range curve). Collectively, these functions can be used to explore, compare, and contrast theoretical performance of a wide range of transmitter and receiver network designs.
 
 
 #### Visualization and data exploration

--- a/man/adjust_playback_time.Rd
+++ b/man/adjust_playback_time.Rd
@@ -18,7 +18,7 @@ adjust_playback_time(
 See details.}
 
 \item{input}{character, path to video file (any file type supported by
-\link[av:encoding]{av::av_encode_video}; e.g., *.mp4, *.wmv, etc)}
+\link[av:av_encode_video]{av::av_encode_video}; e.g., *.mp4, *.wmv, etc)}
 
 \item{output_dir}{character, output directory, default is working directory}
 
@@ -37,7 +37,7 @@ path and name of output file with be returned.
 Speed up or slow down playback of video
 }
 \details{
-A simple wrapper for \link[av:encoding]{av::av_encode_video}.
+A simple wrapper for \link[av:av_encode_video]{av::av_encode_video}.
 
 \code{adjust_playback_time} adjusts playback speed of video.
 \code{scale_factor} controls the magnitude of speed-up or slow-down by

--- a/man/detect_transmissions.Rd
+++ b/man/detect_transmissions.Rd
@@ -20,12 +20,12 @@ detect_transmissions(
 (numeric or POSIXct column) of signal transmissions.\cr \emph{OR} \cr An
 object of class \code{\link[sf:sf]{sf::sf()}} or \code{\link[sf:sfc]{sf::sfc()}} containing
 \code{POINT} features (geometry column) and time (see \code{colNames}).
-(\code{\link[sp:SpatialPoints]{sp::SpatialPointsDataFrame()}} is also allowed.)}
+(\code{\link[sp:SpatialPointsDataFrame]{sp::SpatialPointsDataFrame()}} is also allowed.)}
 
 \item{recLoc}{A data frame with coordinates (two numeric columns) of receiver
 locations.\cr \emph{OR} \cr An object of class \code{\link[sf:sf]{sf::sf()}} or
 \code{\link[sf:sfc]{sf::sfc()}} containing a \code{POINT} feature (geometry column)
-for each receiver. (\code{\link[sp:SpatialPoints]{sp::SpatialPointsDataFrame()}} is also
+for each receiver. (\code{\link[sp:SpatialPointsDataFrame]{sp::SpatialPointsDataFrame()}} is also
 allowed.)}
 
 \item{detRngFun}{A function that defines detection range curve; must accept a

--- a/man/glatos.Rd
+++ b/man/glatos.Rd
@@ -39,11 +39,11 @@ https://github.com/ocean-tracking-network/glatos/wiki/installation-instructions.
 \subsection{Data loading and processing}{
 \enumerate{
 \item \href{https://github.com/ocean-tracking-network/glatos/blob/main/R/load-read_glatos_detections.r}{\code{read_glatos_detections}} and \href{https://github.com/ocean-tracking-network/glatos/blob/main/R/load-read_otn_detections.r}{\code{read_otn_detections}} provide fast data loading from standard GLATOS and OTN data files to a single structure that is compatible with other glatos functions.
-\item \href{https://github.com/ocean-tracking-network/glatos/blob/main/R/load-read_glatos_receivers.r}{\code{read_glatos_receivers}} and \href{https://github.com/ocean-tracking-network/glatos/blob/main/R/load-read_otn_deployments.r}{\code{read_otn_deployments}} reads receiver location histories from standard GLATOS and OTN data files to a single structure that is compatible with other glatos functions.
+\item \href{https://github.com/ocean-tracking-network/glatos/blob/main/R/load-read_glatos_receivers.r}{\code{read_glatos_receivers}} and \href{https://github.com/ocean-tracking-network/glatos/blob/main/R/load-read_otn_deployments.R}{\code{read_otn_deployments}} reads receiver location histories from standard GLATOS and OTN data files to a single structure that is compatible with other glatos functions.
 \item \href{https://github.com/ocean-tracking-network/glatos/blob/main/R/load-read_glatos_workbook.r}{\code{read_glatos_workbook}} reads project-specific receiver history and fish taggging and release data from a standard glatos workbook file.
 \item \href{https://github.com/ocean-tracking-network/glatos/blob/main/R/load-read_vemco_tag_specs.r}{\code{read_vemco_tag_specs}} reads transmitter (tag) specifications and operating schedule.
 \item \href{https://github.com/ocean-tracking-network/glatos/blob/main/R/proc-real_sensor_values.r}{\code{real_sensor_values}} converts 'raw' transmitter sensor (e.g., depth, temperature) to 'real'-scale values (e.g., depth in meters) using transmitter specification data (e.g., from read_vemco_tag_specs).
-\item \href{https://github.com/ocean-tracking-network/glatos/blob/main/R/load-prepare_tag_sheet.r}{\code{prepare_tag_sheet}} and \href{https://github.com/ocean-tracking-network/glatos/blob/main/R/load-prepare_deploy_sheet.r}{\code{prepare_deploy_sheet}} load OTN metadata sheets for Tagging and Deployment of Receivers and formats them for converting to ATT Data.
+\item \href{https://github.com/ocean-tracking-network/glatos/blob/main/R/load-prepare_tag_sheet.R}{\code{prepare_tag_sheet}} and \href{https://github.com/ocean-tracking-network/glatos/blob/main/R/load-prepare_deploy_sheet.R}{\code{prepare_deploy_sheet}} load OTN metadata sheets for Tagging and Deployment of Receivers and formats them for converting to ATT Data.
 \item \code{vue_convert} and \code{vdat_convert} extracts data from proprietary receiver
 files (.vrl, .vdat) using Innovasea's VUE and VDAT software (packaged with
 Fathom Connect software).
@@ -62,7 +62,7 @@ exported from Innovasea's VUE software.
 \item \href{https://github.com/ocean-tracking-network/glatos/blob/main/R/summ-detection_events.r}{\code{detection_events}} distills detection data down to a much smaller number of discrete detection events, defined as a change in location or time gap that exceeds a threshold.
 \item \href{https://github.com/ocean-tracking-network/glatos/blob/main/R/summ-summarize_detections.r}{\code{summarize_detections}} calculates number of fish detected, number of detections, first and last detection timestamps, and/or mean location of receivers or groups, depending on specific type of summary requested.
 \item \href{https://github.com/ocean-tracking-network/glatos/blob/main/R/summ-residence_index.r}{\code{residence_index}} calculates the relative proportion of time spent at each location.
-\item \href{https://github.com/ocean-tracking-network/glatos/blob/main/R/REI.r}{\code{REI}} calculates the relative activity at each receiver based on number of unique
+\item \code{REI} calculates the relative activity at each receiver based on number of unique
 species and individual animals.
 \item \code{detection_range_model} for estimating detection range at which a certain
 detection efficiency is expected, using output from Innovasea's range testing
@@ -74,7 +74,7 @@ software.
 \enumerate{
 \item \href{https://github.com/ocean-tracking-network/glatos/blob/main/R/sim-calc_collision_prob.r}{\code{calc_collision_prob}} estimates the probability of collisions for pulse-position-modulation type co-located telemetry transmitters. This is useful for determining the number of fish to release or tag specifications (e.g., delay).
 \item \href{https://github.com/ocean-tracking-network/glatos/blob/main/R/sim-receiver_line_det_sim.r}{\code{receiver_line_det_sim}} simulates detection of acoustic-tagged fish crossing a receiver line (or single receiver). This is useful for determining optimal spacing of receviers in a line and tag specifications (e.g., delay).
-\item \href{https://github.com/ocean-tracking-network/glatos/blob/main/R/simutil-crw_in_polygon.r}{\code{crw_in_polygon}}, \href{https://github.com/ocean-tracking-network/glatos/blob/main/R/sim-transmit_along_path.r}{\code{transmit_along_path}}, and \href{https://github.com/ocean-tracking-network/glatos/blob/main/R/sim-detect_transmissions.r}{\code{detect_transmissions}} individually simulate random fish movement paths within a water body (\emph{crw_in_polygon}: a random walk in a polygon), tag signal transmissions along those paths (\emph{transmit_along_path}: time series and locations of transmissions based on tag specs), and detection of those transmittions by receivers in a user-defined receiver network (\emph{detect_transmissions}: time series and locations of detections based on detection range curve). Collectively, these functions can be used to explore, compare, and contrast theoretical performance of a wide range of transmitter and receiver network designs.
+\item \code{crw_in_polygon}, \href{https://github.com/ocean-tracking-network/glatos/blob/main/R/sim-transmit_along_path.r}{\code{transmit_along_path}}, and \href{https://github.com/ocean-tracking-network/glatos/blob/main/R/sim-detect_transmissions.r}{\code{detect_transmissions}} individually simulate random fish movement paths within a water body (\emph{crw_in_polygon}: a random walk in a polygon), tag signal transmissions along those paths (\emph{transmit_along_path}: time series and locations of transmissions based on tag specs), and detection of those transmittions by receivers in a user-defined receiver network (\emph{detect_transmissions}: time series and locations of detections based on detection range curve). Collectively, these functions can be used to explore, compare, and contrast theoretical performance of a wide range of transmitter and receiver network designs.
 }
 }
 
@@ -116,6 +116,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Christopher Holbrook \email{cholbrook@glfc.org}
   \item Todd Hayden
   \item Thomas Binder
   \item Jon Pye

--- a/man/greatLakesTrLayer.Rd
+++ b/man/greatLakesTrLayer.Rd
@@ -30,7 +30,7 @@ raster::plot(raster::raster(greatLakesTrLayer))
 
 }
 \seealso{
-\link{interpolate_path}, \link[gdistance:gdistance]{gdistance::gdistance}
+\link{interpolate_path}, \link[gdistance:gdistance]{gdistance}
 }
 \author{
 Todd Hayden (rebuilt by C. Holbrook)

--- a/man/interpolate_path.Rd
+++ b/man/interpolate_path.Rd
@@ -59,7 +59,7 @@ receivers) that avoid 'impossible' movements (e.g., over land for
 fish). The shortest non-linear path between two locations is
 calculated using a transition matrix layer that represents the
 'cost' of an animal moving between adjacent grid cells.  The
-transition matrix layer (see \link[gdistance:gdistance]{gdistance::gdistance}) is created from
+transition matrix layer (see \link[gdistance:gdistance]{gdistance}) is created from
 a polygon shapefile using \link{make_transition} or from a
 \code{RasterLayer} object using \link[gdistance:transition]{transition}. In
 \code{make_transition}, each cell in the output transition layer
@@ -84,7 +84,7 @@ be used for all points when \code{lnl_thresh} > 1 and linear
 interpolation will be used for all points when \code{lnl_thresh}
 = 0.
 
-All linear interpolation is done by \code{\link[stats:approxfun]{stats::approx()}} with
+All linear interpolation is done by \code{\link[stats:approx]{stats::approx()}} with
 argument \code{ties = "ordered"} controlling how tied \code{x} values
 are handled. See \code{\link[stats:approxfun]{stats::approxfun()}}.
 }

--- a/man/make_transition.Rd
+++ b/man/make_transition.Rd
@@ -30,7 +30,7 @@ A list with two elements:
 \describe{
 \item{transition}{a geo-corrected transition raster layer where land = 0
 and water = 1
-(see \code{\link[gdistance:Transition-classes]{gdistance::Transition}})}
+(see \code{\link[gdistance:Transition-class]{gdistance::Transition}})}
 \item{rast}{rasterized input layer of class \code{raster}}}
 }
 \description{

--- a/man/make_video.Rd
+++ b/man/make_video.Rd
@@ -42,10 +42,10 @@ Ignored if \code{vfilter} is passed via \code{...}.}
 \item{overwrite}{logical, overwrite existing output file? (default = FALSE)}
 
 \item{verbose}{logical, show output from
-\link[av:encoding]{av::av_encode_video}? Default = FALSE.}
+\link[av:av_encode_video]{av::av_encode_video}? Default = FALSE.}
 
 \item{...}{optional arguments passed to
-\link[av:encoding]{av::av_encode_video}. Such as framerate, vfilter, codec.}
+\link[av:av_encode_video]{av::av_encode_video}. Such as framerate, vfilter, codec.}
 }
 \value{
 One video animation will be written disk and the path and file name
@@ -53,7 +53,7 @@ will be returned.
 }
 \description{
 Stitch a sequence of images into a video animation. A simple wrapper for
-\link[av:encoding]{av::av_encode_video}.
+\link[av:av_encode_video]{av::av_encode_video}.
 }
 \details{
 This function was overhauled in glatos v 0.4.1 to simplify inputs
@@ -63,12 +63,12 @@ input arguments have changed, as described above. Starting with glatos v
 0.4.0 or earlier will fail.
 
 \code{make_video} is a simple wrapper of
-\link[av:encoding]{av::av_encode_video}. It is intended to allow creation of
+\link[av:av_encode_video]{av::av_encode_video}. It is intended to allow creation of
 videos from images (frames) created by \link[=make_frames]{glatos::make_frames}
 as simple as possible. More advanced features of \code{av}, can be used by
-including any argument of \link[av:encoding]{av::av_encode_video} in the
+including any argument of \link[av:av_encode_video]{av::av_encode_video} in the
 call to \code{make_video}, or by calling
-\link[av:encoding]{av::av_encode_video} directly. More information about the
+\link[av:av_encode_video]{av::av_encode_video} directly. More information about the
 \code{av} package is available at
 https://cran.r-project.org/web/packages/av/index.html and
 https://docs.ropensci.org/av/.
@@ -94,7 +94,7 @@ specified duration, so the output duration may differ from that specified.
 If the output frame rate exceeds 30 fps, then a warning will alert the user
 that some individual frame content may not be visible to users. Video
 duration may also be controlled by setting the \code{framerate} argument of
-\link[av:encoding]{av::av_encode_video}. See \code{...} above.
+\link[av:av_encode_video]{av::av_encode_video}. See \code{...} above.
 }
 \examples{
 \dontrun{

--- a/man/read_glatos_detections.Rd
+++ b/man/read_glatos_detections.Rd
@@ -28,7 +28,7 @@ a data.frame of class \code{glatos_detections}.
 }
 \details{
 Data are loaded using \link[data.table:fread]{fread} and timestamps are
-coerced to POSIXct using \link[lubridate:parse_date_time]{fast_strptime}. All times
+coerced to POSIXct using \link[lubridate:fast_strptime]{fast_strptime}. All times
 must be in UTC timezone per GLATOS standard.
 
 Column \code{animal_id} is considered a required column by many other

--- a/man/read_glatos_receivers.Rd
+++ b/man/read_glatos_receivers.Rd
@@ -27,7 +27,7 @@ data.frame of class \code{glatos_receivers}.
 }
 \details{
 Data are loaded using \link[data.table:fread]{fread} and timestamps are
-coerced to POSIXct using \link[lubridate:parse_date_time]{fast_strptime}. All
+coerced to POSIXct using \link[lubridate:fast_strptime]{fast_strptime}. All
 timestamps must be 'YYYY-MM-DD HH:MM' format and in UTC timezone per GLATOS
 standard.
 }

--- a/man/read_otn_deployments.Rd
+++ b/man/read_otn_deployments.Rd
@@ -35,7 +35,7 @@ a data.frame of class \code{glatos_receivers}.
 }
 \details{
 Data are loaded using \code{\link[data.table:fread]{data.table::fread()}} package and timestamps
-are coerced to POSIXct using \code{\link[lubridate:parse_date_time]{lubridate::fast_strptime()}}. All
+are coerced to POSIXct using \code{\link[lubridate:fast_strptime]{lubridate::fast_strptime()}}. All
 times must be in UTC timezone per GLATOS standard.
 
 Column names are changed to match GLATOS standard columns when possible.

--- a/man/read_otn_detections.Rd
+++ b/man/read_otn_detections.Rd
@@ -24,7 +24,7 @@ a data.frame of class \code{glatos_detections}.
 }
 \details{
 Data are loaded using \code{\link[data.table:fread]{data.table::fread()}} package and timestamps
-are coerced to POSIXct using \code{\link[lubridate:parse_date_time]{lubridate::fast_strptime()}}. All
+are coerced to POSIXct using \code{\link[lubridate:fast_strptime]{lubridate::fast_strptime()}}. All
 times must be in UTC timezone per GLATOS standard.
 
 Column names are changed to match GLATOS standard columns when possible.

--- a/man/shoreline.Rd
+++ b/man/shoreline.Rd
@@ -27,7 +27,7 @@ Todd's original file name was 'coastline_poly_modified_rivers'.
 }
 
 \section{Used to make \link{great_lakes_polygon}.}{
-NA
+
 }
 
 \examples{

--- a/man/transmit_along_path.Rd
+++ b/man/transmit_along_path.Rd
@@ -18,7 +18,7 @@ transmit_along_path(
 \item{path}{A data frame or matrix with at least two rows and named columns
 with coordinates that define path.\cr \emph{OR} \cr A object of class
 \code{\link[sf:sf]{sf::sf()}} or \code{\link[sf:sfc]{sf::sfc()}} containing \code{POINT}
-features with a geometry column. (\code{\link[sp:SpatialPoints]{sp::SpatialPointsDataFrame()}}
+features with a geometry column. (\code{\link[sp:SpatialPointsDataFrame]{sp::SpatialPointsDataFrame()}}
 is also allowed.)}
 
 \item{vel}{A numeric scalar with movement velocity along track; assumed


### PR DESCRIPTION
There were a few dead links on the glatos README page, caused by links to files with a ".R" suffix, changes in the README to the correct file names. Another option would've been to change the R files to suffix ".r", I will let the package maintainers (@chrisholbrook ) decide which option is best.

There were a few dead links on the glatos README page, caused by files that are not in the R folder, changes in the README to remove those links.

Changes to .gitignore and .Rbuildignore that were done by the latest version of RStudio.
